### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/enderzoo/lang/en_US.lang
+++ b/src/main/resources/assets/enderzoo/lang/en_US.lang
@@ -6,6 +6,7 @@ item.witheringDust.name=Withering Dust
 item.confusingDust.name=Confusing Powder
 item.enderFragment.name=Ender Fragment
 item.guardiansBow.name=Guardians Bow
+item.enderZooIcon.name=EnderZoo Icon
 
 
 //Mobs


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.