### PR TITLE
Fix concussion creeper portal effect applying to all players

### DIFF
--- a/src/main/java/crazypants/enderzoo/ClientProxy.java
+++ b/src/main/java/crazypants/enderzoo/ClientProxy.java
@@ -81,7 +81,11 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void setInstantConfusionOnPlayer(EntityPlayer ent, int duration) {
         ent.addPotionEffect(new PotionEffect(Potion.confusion.getId(), duration, 1, true));
-        Minecraft.getMinecraft().thePlayer.timeInPortal = 1;
+        // Only show the portal screen effect for the local player when they were
+        // actually caught in the blast, not for every client that sees the explosion.
+        if (ent == Minecraft.getMinecraft().thePlayer) {
+            Minecraft.getMinecraft().thePlayer.timeInPortal = 1;
+        }
     }
 
 }


### PR DESCRIPTION
The concussion creeper's portal screen effect was applied to every player on every client that saw the explosion, not just the ones caught in the blast. The problem was that the client proxy always set `timeInPortal` on the local `thePlayer` regardless of which entity was passed in, so any client running the creeper's onUpdate loop would flash the portal effect on its own player whenever any player was in range. Fixed by only setting `timeInPortal` when the affected entity is the local player, which is only true if that player was actually within the explosion radius.